### PR TITLE
Run all phases in derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,6 @@ pkgs.stdenv.mkDerivation rec {
   name = "bundix";
   src = ./.;
 
-  phases = "installPhase";
   installPhase = ''
     mkdir -p $out
     makeWrapper $src/bin/bundix $out/bin/bundix \


### PR DESCRIPTION
Running only some phases can lead to unexpected downstream behavior. E.g., setting `patches` in an `overrideAttrs` will have no effect since the phase does not run. Since this drv builds when running all phases, it’s not clear why this was done, perhaps for a reason that no longer exists, or simply as an (over?) optimization.