### PR TITLE
Fix bug with platform_mapping scope

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -9,9 +9,7 @@ require_relative 'bundix/version'
 require_relative 'bundix/source'
 require_relative 'bundix/nixer'
 
-platform_mapping = {}
-
-{
+PLATFORM_MAPPING = {
   'ruby' => [{ engine: 'ruby' }, { engine: 'rbx' }, { engine: 'maglev' }],
   'mri' => [{ engine: 'ruby' }, { engine: 'maglev' }],
   'rbx' => [{ engine: 'rbx' }],
@@ -21,16 +19,14 @@ platform_mapping = {}
   'mingw' => [{ engine: 'mingw' }],
   'truffleruby' => [{ engine: 'ruby' }],
   'x64_mingw' => [{ engine: 'mingw' }]
-}.each do |name, list|
-  platform_mapping[name] = list
+}.each_with_object({}) do |(name, list), mappings|
+  mappings[name] = list
   %w[1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2].each do |version|
-    platform_mapping["#{name}_#{version.sub(/[.]/, '')}"] = list.map do |platform|
+    mappings["#{name}_#{version.sub(/[.]/, '')}"] = list.map do |platform|
       platform.merge(version: version)
     end
   end
 end
-
-PLATFORM_MAPPING = platform_mapping
 
 class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'

--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -30,6 +30,8 @@ platform_mapping = {}
   end
 end
 
+PLATFORM_MAPPING = platform_mapping
+
 class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
@@ -142,7 +144,7 @@ class Bundix
   def platforms(spec)
     # c.f. Bundler::CurrentRuby
     platforms = @gem_deps.fetch(spec.name).platforms.map do |platform_name|
-      platform_mapping[platform_name.to_s]
+      PLATFORM_MAPPING[platform_name.to_s]
     end.flatten
 
     { 'platforms' => platforms }


### PR DESCRIPTION
Thanks for your work on this project! When using it I ran into a problem where bundix would throw an exception on some gems (notably `irb`, for some reason):

```
Skipping irb: undefined local variable or method `platform_mapping' for #<Bundix:0x0000000104300c50 [snip]>

      platform_mapping[platform_name.to_s]
      ^^^^^^^^^^^^^^^^
Did you mean?  platform_name
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:145:in `block in platforms'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:144:in `map'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:144:in `platforms'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:98:in `build_source'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:79:in `block in build_gemspec'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:78:in `to_h'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:78:in `build_gemspec'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:71:in `block in convert'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:70:in `transform_values'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix.rb:70:in `convert'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix/commandline.rb:141:in `build_gemset'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix/commandline.rb:35:in `run'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/lib/bundix/commandline.rb:15:in `run'
/nix/store/1g5i8jb49hzrwdayxwd26j2bb9jvnn7n-h438cbmcfl8b19kd71mqna13p102x9as-source/bin/bundix:6:in `<main>'
```

I think this is just due to an earlier refactor that changed `PLATFORM_MAPPING` to `platform_mapping` (i.e. from a constant to a local variable). As a result it's not visible inside the `Bundix#platforms` method.

This change fixes the bug. I'm a little surprised that apparently no one else has hit this...