### PR TITLE
Update source.rb to not run a regex on nil

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -105,7 +105,7 @@ class Bundix
           next unless spec.platform =~ platform
         end
 
-        hash = nix_prefetch_url(path)[SHA256_32]
+        hash = nix_prefetch_url(path)
         return format_hash(hash), platform if hash
       end
 


### PR DESCRIPTION
if hash is nil at this point, running the regex will produce:

`(irb):2:in '<main>': undefined method '[]' for nil:NilClass (NoMethodError) `

it also doesn't seem to be necessary to do this here, since the next line calls `format_hash` if hash isn't nil.

format_hash will still run the regex if required.