### PR TITLE
Add default platform value to #fetch_local_hash

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -111,6 +111,7 @@ class Bundix
     end
 
     def fetch_local_hash(spec)
+      platform = Gem::Platform::RUBY # default platform value
       has_platform = spec.platform && spec.platform != Gem::Platform::RUBY
       name_version = "#{spec.name}-#{spec.version}"
       filename = has_platform ? "#{name_version}-*" : name_version


### PR DESCRIPTION
Not having this pulls in the wrong `target` value into gemset.nix for gems like so:

```
  coderay = {
    groups = ["default"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
      target = null;
      type = "gem";
    };
    targets = [];
    version = "1.1.3";
  };
```

Whereas it should be "ruby" instead:

```
  coderay = {
    groups = ["default"];
    platforms = [];
    source = {
      remotes = ["https://rubygems.org"];
      sha256 = "0jvxqxzply1lwp7ysn94zjhh57vc14mcshw1ygw14ib8lhc00lyw";
      target = "ruby";
      type = "gem";
    };
    targets = [];
    version = "1.1.3";
  };
```

Which results in a weird Nix shell error:

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/6nfpbajyzwxq6wrhn20l13rhckhv26rc-source/pkgs/stdenv/generic/make-derivation.nix:348:7

       … while evaluating attribute 'buildInputs' of derivation 'nix-shell'

         at /nix/store/6nfpbajyzwxq6wrhn20l13rhckhv26rc-source/pkgs/stdenv/generic/make-derivation.nix:395:7:

          394|       depsHostHost                = elemAt (elemAt dependencies 1) 0;
          395|       buildInputs                 = elemAt (elemAt dependencies 1) 1;
             |       ^
          396|       depsTargetTarget            = elemAt (elemAt dependencies 2) 0;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: cannot coerce null to a string
```

One can reproduce it by:

```
$ nix flake init -t github:inscapist/ruby-nix/main
$ nix develop
$ echo 'source "https://rubygems.org"' > Gemfile
$ echo 'gem "pry"' >> Gemfile
$ bundle-lock
$ bundix
$ exit
$ nix develop
```

It may fail to reproduce on the first take since it seems to be caused by the branch fetching gems from the local store.