### PR TITLE
Support downloading gems from private git repositories via https

### DIFF
--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -95,6 +95,12 @@ class Bundix
       home = ENV["HOME"]
       ENV["HOME"] = "/homeless-shelter"
 
+      uri_parsed = URI(uri)
+      if %w[http https].include?(uri_parsed.scheme) && !uri_parsed.user
+        inject_credentials_from_bundler_settings(uri_parsed)
+        uri = uri_parsed.to_s
+      end
+
       args = []
       args << "--url" << uri
       args << "--rev" << revision


### PR DESCRIPTION
The solution uses the same credential injecting from Bundler settings as regular downloads.