### PR TITLE
[fix] bundix to be overridable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
 
       bundler = pkgs.bundler.override { ruby = rubyCurrent; };
 
-      bundix = import ./default.nix {
+      bundix = pkgs.callPackage ./default.nix {
         inherit pkgs ruby bundler;
         inherit (pkgs) nix nix-prefetch-git;
       };


### PR DESCRIPTION
Now you can override `ruby`, `bundler` etc. for `bundix`. 

```
bundix_new = bundix.packages.x86_64-linux.default.override {
  inherit ruby;
  bundler = bundler.override {
    inherit ruby;
  };
};
```