### PR TITLE
update from `nix-hash` to `nix hash convert` to supress warnings

### DIFF
--- a/lib/bundix.rb
+++ b/lib/bundix.rb
@@ -35,7 +35,6 @@ class Bundix
   NIX_INSTANTIATE = 'nix-instantiate'
   NIX_PREFETCH_URL = 'nix-prefetch-url'
   NIX_PREFETCH_GIT = 'nix-prefetch-git'
-  NIX_HASH = 'nix-hash'
   NIX_SHELL = 'nix-shell'
 
   SHA256_32 = /^[a-z0-9]{52}$/.freeze

--- a/lib/bundix/source.rb
+++ b/lib/bundix/source.rb
@@ -107,7 +107,7 @@ class Bundix
     end
 
     def format_hash(hash)
-      sh(NIX_HASH, "--type", "sha256", "--to-base32", hash)[SHA256_32]
+      sh("nix", "hash", "convert", "--hash-algo", "sha256", "--to", "nix32", hash)[SHA256_32]
     end
 
     def fetch_local_hash(spec)


### PR DESCRIPTION
When running `bundix`, I see this warning after every gem processed:
```
warning: The old format conversion sub commands of `nix hash` where deprecated in favor of `nix hash convert`.
```
This change updates the old `nix-hash` command to use `nix hash convert` so those warnings don't show up anymore. I tested that the commands are identical using a Gemfile for a new Rails project, and both resulted in the same `gemset.nix`.